### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - secure: "fA5rOTwEEphRdaCZ3eJBDNz5NpaO3oe8+wPjM0wdERyxQxj/eKMUQlje+TSOnlgYb/PlR5szAMJWAPrRBOuHaV2VGRAn38Ho/bTaU0tHCH4stbvg4sV4MjBYUuyclWYh7wXDs7NiwJGc0rwX5cLpSmcUD+A+cqabXFxQuzKNZrVpqHpdvMwk2uk/5DxCP+2kD4klkEEAY/wyaCY+3LBYzLU/0f9RhSAPWWAnf3XoSBCyqb2LlqzrltucDRx3h1Sy5R4CwTd90D6DIRPGIfx1sSfX9oktuv3ztUBPd3wxjfioG1mMcbFb/YC/YLqp2l0DThSEvyS26gXxhbW5M1ng9ZYH++w/Ij13tcKgKJ+aoKocpfsl1PyqpdDio8FROID8T87e6NfsgB7fevu7MepFHJwWohyu1RSqFx4lXcwviLqIxlTH8r3/yOwSUs1QRIRK05DwqF0AFL4JDkCaAlnImmaP5XPN0wf9S3Y2Od3Y2JSaW2s34T4QeoEKR5zvmRStzxVeLTlcEjRzxHr4YMYNDHWVDSelH+2RshowIwFXoKcQAX18PFJma2LTP07KmuWr9U9MRU6sXti8yVyjH+QQWzUtSndst2xXZ5lwnGNFag5pOMZnRAAAbgXSaoLnYIMiT18AmWRNTD9TE84i0NY0JwoO4xQokxy+mMGwvhEcMSk="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.6
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
